### PR TITLE
Add support for extra files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Auto detect text files and perform LF normalization
+* text=Auto
+*.sh text eol=LF
+*.gitignore text eol=LF
+*.gitattributes text eol=LF

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Tested on a host running Ubuntu 20.04.1.
 
 ### Usage
 ```
-Usage: ubuntu-autoinstall-generator.sh [-h] [-v] [-a] [-e] [-u user-data-file] [-m meta-data-file] [-k] [-c] [-r] [-s source-iso-file] [-d destination-iso-file]
+Usage: ubuntu-autoinstall-generator.sh [-h] [-v] [-a] [-e] [-u user-data-file] [-m meta-data-file] [-k] [-c] [-r] [-s source-iso-file] [-d destination-iso-file] [-x extra-file-or-folder-path]
 
 💁 This script will create fully-automated Ubuntu 20.04 Focal Fossa installation media.
 
@@ -55,6 +55,8 @@ Available options:
                         That file will be used by default if it already exists.
 -d, --destination       Destination ISO file. By default <script directory>/ubuntu-autoinstall-<current date>.iso will be
                         created, overwriting any existing file.
+-x, --extra-file        Additional file or files using standard folder / file wildcards to include in the image.
+                        Used for customisations of the image for specific deployment purposes
 ```
 
 ### Example

--- a/ubuntu-autoinstall-generator.sh
+++ b/ubuntu-autoinstall-generator.sh
@@ -56,6 +56,8 @@ Available options:
                         That file will be used by default if it already exists.
 -d, --destination       Destination ISO file. By default ${script_dir}/ubuntu-autoinstall-$today.iso will be
                         created, overwriting any existing file.
+-x, --extra-file        Additional file or files using standard folder / file wildcards to include in the image.
+                        Used for customisations of the image for specific deployment purposes
 EOF
         exit
 }
@@ -75,6 +77,7 @@ function parse_params() {
         use_hwe_kernel=0
         md5_checksum=1
         use_release_iso=0
+        extra_file=''
 
         while :; do
                 case "${1-}" in
@@ -99,6 +102,10 @@ function parse_params() {
                         ;;
                 -m | --meta-data)
                         meta_data_file="${2-}"
+                        shift
+                        ;;
+                -x | --extra-file)
+                        extra_file="${2-}"
                         shift
                         ;;
                 -?*) die "Unknown option: $1" ;;
@@ -241,6 +248,10 @@ if [ ${all_in_one} -eq 1 ]; then
                 cp "$meta_data_file" "$tmpdir/nocloud/meta-data"
         else
                 touch "$tmpdir/nocloud/meta-data"
+        fi
+        if [[ -n "${extra_file}" ]]; then
+                log "🧩 Adding specified extra files"
+                cp -r "$extra_file" "$tmpdir/nocloud/"
         fi
         sed -i -e 's,---, ds=nocloud;s=/cdrom/nocloud/  ---,g' "$tmpdir/isolinux/txt.cfg"
         sed -i -e 's,---, ds=nocloud\\\;s=/cdrom/nocloud/  ---,g' "$tmpdir/boot/grub/grub.cfg"


### PR DESCRIPTION
Add support for extra files. Recommend a subfolder be created and then referenced with the -x, --extra-file option for simplicity.