### PR TITLE
skip language selection screen and grub screen

### DIFF
--- a/ubuntu-autoinstall-generator.sh
+++ b/ubuntu-autoinstall-generator.sh
@@ -231,6 +231,7 @@ log "🧩 Adding autoinstall parameter to kernel command line..."
 sed -i -e 's/---/ autoinstall  ---/g' "$tmpdir/isolinux/txt.cfg"
 sed -i -e 's/---/ autoinstall  ---/g' "$tmpdir/boot/grub/grub.cfg"
 sed -i -e 's/---/ autoinstall  ---/g' "$tmpdir/boot/grub/loopback.cfg"
+sed -i -r 's/timeout\s+[0-9]+/timeout 1/g' "$tmpdir/isolinux/isolinux.cfg"
 log "👍 Added parameter to UEFI and BIOS kernel command lines."
 
 if [ ${all_in_one} -eq 1 ]; then


### PR DESCRIPTION
even with an autoinstall-user-data from a manually installed server I was getting stuck at the language selection screen and install selection screen. after clicking install it would do everything from my cloud-init.
This change skips those screens.